### PR TITLE
Add Snaplert website change monitoring tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1099,6 +1099,7 @@ Based on that data, you can find the most popular ones and their alternatives.
 ## News, RSS Feed
 - [Akregator](https://kontact.kde.org/components/akregator.html) - Akregator helps you to keep informed about new stories on websites like KDE Dot News and Planet KDE blogs. The technology used is RSS and many sites support it.
 - [Changedetection.io](https://github.com/dgtlmoon/changedetection.io) - changedetection.io - The best and simplest self-hosted free open source website change detection tracking, monitoring and notification service. An alternative to Visualping, Watchtower etc. Designed for simplicity - the main goal is to simply monitor which websites had a text change for free. Free Open source web page change detection
+- [Snaplert](https://snaplert.com) - Hosted website change monitoring with visual pixel diffs, AI-powered change summaries, element-level zone picker, and before/after screenshot alerts. Free during open beta.
 - [Chinese Security RSS](https://github.com/zhengjim/Chinese-Security-RSS) - 网络安全资讯的RSS订阅，网络安全博客的RSS订阅，网络安全公众号的RSS订阅 
 - [CyberSecurityRSS](https://github.com/zer0yu/CyberSecurityRSS) - CyberSecurityRSS: 优秀的网络安全知识来源 / A collection of cybersecurity rss to make you better!.
 - [detoxed.news](https://github.com/tom-james-watson/detoxed.news) - The important news, without the toxicity.


### PR DESCRIPTION
[Snaplert](https://snaplert.com) is a hosted website change monitoring tool that complements Changedetection.io with a visual-first, no-setup approach:

- **Visual pixel diffs** — before/after screenshot comparisons showing exactly what changed
- **AI-powered summaries** — Claude explains what changed in plain English
- **Element-level zone picker** — monitor specific page sections, not just full page URLs
- **5-minute check intervals** with email alerts and webhooks
- **Free during open beta** — no Docker, no self-hosting required

Added alongside Changedetection.io in the News/RSS Feed section as a complementary hosted alternative.