### PR TITLE
Add DeerImage

### DIFF
--- a/README.md
+++ b/README.md
@@ -859,6 +859,7 @@ Based on that data, you can find the most popular ones and their alternatives.
   - [Chaotica](https://chaoticafractals.com/download) -  Chaotica is free for noncommercial use, and can render up to 1.23 megapixel images (e.g. 1280x960 resolution) and up to 30 second 480p animations without a licence.
   - [Cura](https://github.com/Ultimaker/Cura) - 3D printer / slicing GUI built on top of the Uranium framework.
   - [DarkTable](https://github.com/darktable-org/darktable) - open source photography workflow application and raw developer. A virtual lighttable and darkroom for photographers. [darktable.org](https://www.darktable.org)
+  - [DeerImage](https://deerimage.com/) - Free browser-based image tools for compression, conversion, resizing, ID photos, signatures, and drawing without an account.
   - [DigiKam from KDE](https://www.digikam.org) - [Github](https://github.com/KDE/digikam) Advanced open-source digital photo management application that runs on Linux, Windows, and MacOS. The application provides a comprehensive set of tools for importing, managing, editing, and sharing photos and raw files.
   - [ExifCleaner](https://github.com/szTheory/exifcleaner) - Cross-platform desktop GUI app to clean image metadata.
   - [GIMP](https://gitlab.gnome.org/GNOME/gimp) - GNU Image Manipulation Program [gimp.org](https://www.gimp.org)


### PR DESCRIPTION
## What changed

Added DeerImage to the Image and pictures section.

## Why

It provides free browser-based tools for common image tasks, including compression, conversion, resizing, ID photos, signatures, and drawing without requiring an account.

## Validation

- Confirmed DeerImage is not already listed
- Kept the existing list format and alphabetical placement
- Added only one resource entry
